### PR TITLE
Updates for AMD GPA 4.0 integration

### DIFF
--- a/renderdoc/driver/ihv/amd/amd_counters.h
+++ b/renderdoc/driver/ihv/amd/amd_counters.h
@@ -108,7 +108,7 @@ private:
   void InitializeCmdInfo();
   void DeInitializeCmdInfo();
   void DeleteSession(uint32_t sessionId);
-  CounterDescription InternalGetCounterDescription(uint32_t internalIndex);
+  CounterDescription InternalGetCounterDescription(GpaSessionId sessionId, uint32_t internalIndex);
 
   std::map<uint32_t, CounterDescription> EnumerateCounters();
   std::map<uint32_t, CounterDescription> m_Counters;

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api.h
@@ -1,5 +1,5 @@
 //==============================================================================
-// Copyright (c) 2010-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2010-2025 Advanced Micro Devices, Inc. All rights reserved.
 /// @author AMD Developer Tools Team
 /// @file
 /// @brief  This is the header file that must be included by an application that
@@ -38,7 +38,7 @@
 #include "gpu_perf_api_types.h"
 
 #define GPA_FUNCTION_TABLE_MAJOR_VERSION_NUMBER \
-    3  ///< API major version -- will be incremented if/when there are non-backwards compatible API changes introduced.
+    4  ///< API major version -- will be incremented if/when there are non-backwards compatible API changes introduced.
 #define GPA_FUNCTION_TABLE_MINOR_VERSION_NUMBER \
     (sizeof(struct _GpaFunctionTable))  ///< API minor version -- set to the structure size; will increase when new API functions are added.
 
@@ -193,13 +193,13 @@ GPA_LIB_DECL GpaStatus GpaCloseContext(GpaContextId gpa_context_id);
 
 /// @brief Gets a mask of the sample types supported by the specified context.
 ///
-/// A call to GPA_CreateSession will fail if the requested sample types are not compatible with the context's sample types.
+/// A call to GpaCreateSession will fail if the requested sample types are not compatible with the context's sample types.
 /// supported by the context.
 ///
 /// @ingroup gpa_context_interrogation
 ///
 /// @param [in] gpa_context_id Unique identifier of the opened context.
-/// @param [out] sample_types The value that will be set to the mask of the supported sample types upon successful execution. This will be a combination of GPA_Sample_Bits.
+/// @param [out] sample_types The value that will be set to the mask of the supported sample types upon successful execution. This will be a combination of GpaContextSampleTypeBits.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
@@ -213,9 +213,9 @@ GPA_LIB_DECL GpaStatus GpaGetSupportedSampleTypes(GpaContextId gpa_context_id, G
 ///
 /// @ingroup gpa_context_interrogation
 ///
-/// @param[in] gpa_context_id Unique identifier of the opened context.
-/// @param[out] device_id The value that will be set to the device id upon successful execution.
-/// @param[out] revision_id The value that will be set to the device revision id upon successful execution.
+/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [out] device_id The value that will be set to the device id upon successful execution.
+/// @param [out] revision_id The value that will be set to the device revision id upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
@@ -226,12 +226,27 @@ GPA_LIB_DECL GpaStatus GpaGetSupportedSampleTypes(GpaContextId gpa_context_id, G
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
 GPA_LIB_DECL GpaStatus GpaGetDeviceAndRevisionId(GpaContextId gpa_context_id, GpaUInt32* device_id, GpaUInt32* revision_id);
 
+/// @brief Overrides the device information for the specified context.
+///
+/// @param context_id Unique identifier of the opened context.
+/// @param num_shader_engines The number of shader engines.
+/// @param num_compute_units The total number of compute units.
+/// @param num_simds The total number of SIMDS.
+/// @param num_waves_per_simd The number of waves per SIMD.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaUpdateDeviceInformation(GpaContextId context_id,
+                                                  GpaUInt32    num_shader_engines,
+                                                  GpaUInt32    num_compute_units,
+                                                  GpaUInt32    num_simds,
+                                                  GpaUInt32    num_waves_per_simd);
+
 /// @brief Gets the device name of the GPU associated with the specified context.
 ///
 /// @ingroup gpa_context_interrogation
 ///
-/// @param[in] gpa_context_id Unique identifier of the opened context.
-/// @param[out] device_name The value that will be set to the device name upon successful execution.
+/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [out] device_name The value that will be set to the device name upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
@@ -242,148 +257,156 @@ GPA_LIB_DECL GpaStatus GpaGetDeviceAndRevisionId(GpaContextId gpa_context_id, Gp
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
 GPA_LIB_DECL GpaStatus GpaGetDeviceName(GpaContextId gpa_context_id, const char** device_name);
 
+/// @brief Gets the GPU hardware generation associated with the specified context.
+///
+/// @ingroup gpa_context_interrogation
+///
+/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [out] hardware_generation The value that will be set to the hardware generation upon successful execution.
+///
+/// @return The GPA result status of the operation.
+/// @retval kGpaStatusOk If the operation is successful.
+/// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
+/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
+/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorFailed If an internal error has occurred.
+/// @retval kGpaStatusErrorException If an unexpected error has occurred.
+GPA_LIB_DECL GpaStatus GpaGetDeviceGeneration(GpaContextId gpa_context_id, GpaHwGeneration* hardware_generation);
+
 /// @defgroup gpa_counter_interrogation GPA Counter Interrogation
 
 /// @brief Gets the number of counters available.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param[in] gpa_context_id Unique identifier of the opened context.
-/// @param[out] number_of_counters The value which will hold the count upon successful execution.
+/// @param [in] gpa_session_id Unique identifier of a session.
+/// @param [out] number_of_counters The value which will hold the count upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetNumCounters(GpaContextId gpa_context_id, GpaUInt32* number_of_counters);
+GPA_LIB_DECL GpaStatus GpaGetNumCounters(GpaSessionId gpa_session_id, GpaUInt32* number_of_counters);
 
 /// @brief Gets the name of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param[in] gpa_context_id Unique identifier of the opened context.
-/// @param[in] index The index of the counter whose name is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// @param[out] counter_name The address which will hold the name upon successful execution.
+/// @param [in] gpa_session_id Unique identifier of a session.
+/// @param [in] index The index of the counter whose name is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] counter_name The address which will hold the name upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterName(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_name);
+GPA_LIB_DECL GpaStatus GpaGetCounterName(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_name);
 
 /// @brief Gets index of a counter given its name (case insensitive).
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the session.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] counter_name The name of the counter whose index is needed.
 /// @param [out] counter_index The address which will hold the index upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorCounterNotFound If the supplied counter name cannot be found.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterIndex(GpaContextId gpa_context_id, const char* counter_name, GpaUInt32* counter_index);
+GPA_LIB_DECL GpaStatus GpaGetCounterIndex(GpaSessionId gpa_session_id, const char* counter_name, GpaUInt32* counter_index);
 
 /// @brief Gets the group of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose group is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_group The address which will hold the group string upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterGroup(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_group);
+GPA_LIB_DECL GpaStatus GpaGetCounterGroup(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_group);
 
 /// @brief Gets the description of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose description is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_description The address which will hold the description upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterDescription(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_description);
+GPA_LIB_DECL GpaStatus GpaGetCounterDescription(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_description);
 
 /// @brief Gets the data type of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose data type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_data_type The value which will hold the counter data type upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterDataType(GpaContextId gpa_context_id, GpaUInt32 index, GpaDataType* counter_data_type);
+GPA_LIB_DECL GpaStatus GpaGetCounterDataType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaDataType* counter_data_type);
 
 /// @brief Gets the usage type of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose usage type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_usage_type The value which will hold the counter usage type upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterUsageType(GpaContextId gpa_context_id, GpaUInt32 index, GpaUsageType* counter_usage_type);
+GPA_LIB_DECL GpaStatus GpaGetCounterUsageType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaUsageType* counter_usage_type);
 
 /// @brief Gets the UUID of the specified counter.
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose UUID is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_uuid The value which will hold the counter UUID upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterUuid(GpaContextId gpa_context_id, GpaUInt32 index, GpaUuid* counter_uuid);
+GPA_LIB_DECL GpaStatus GpaGetCounterUuid(GpaSessionId gpa_session_id, GpaUInt32 index, GpaUuid* counter_uuid);
 
 /// @brief Gets the supported sample type of the specified counter.
 ///
@@ -391,19 +414,18 @@ GPA_LIB_DECL GpaStatus GpaGetCounterUuid(GpaContextId gpa_context_id, GpaUInt32 
 ///
 /// @ingroup gpa_counter_interrogation
 ///
-/// @param [in] gpa_context_id Unique identifier of the opened context.
+/// @param [in] gpa_session_id Unique identifier of a session.
 /// @param [in] index The index of the counter whose sample type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
 /// @param [out] counter_sample_type The value which will hold the counter's supported sample type upon successful execution.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
 /// @retval kGpaStatusErrorNullPointer If any of the parameters are NULL.
-/// @retval kGpaStatusErrorContextNotFound If the supplied context is invalid.
-/// @retval kGpaStatusErrorContextNotOpen If the supplied context has not been opened.
+/// @retval kGpaStatusErrorSessionNotFound If the supplied session is invalid.
 /// @retval kGpaStatusErrorIndexOutOfRange If the counter index is out of range.
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
-GPA_LIB_DECL GpaStatus GpaGetCounterSampleType(GpaContextId gpa_context_id, GpaUInt32 index, GpaCounterSampleType* counter_sample_type);
+GPA_LIB_DECL GpaStatus GpaGetCounterSampleType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaCounterSampleType* counter_sample_type);
 
 /// @brief Gets a string representation of the specified counter data type.
 ///
@@ -452,7 +474,7 @@ GPA_LIB_DECL GpaStatus GpaGetUsageTypeAsStr(GpaUsageType counter_usage_type, con
 ///
 /// @param [in] gpa_context_id The context on which to create the session.
 /// @param [in] gpa_session_sample_type The sample type that will be created on this session.
-/// @param [out] gpa_session_id The address of a GPA_SessionId which will be populated with the created session Id.
+/// @param [out] gpa_session_id The address of a GpaSessionId which will be populated with the created session Id.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
@@ -502,6 +524,208 @@ GPA_LIB_DECL GpaStatus GpaDeleteSession(GpaSessionId gpa_session_id);
 /// @retval kGpaStatusErrorFailed If an internal error has occurred.
 /// @retval kGpaStatusErrorException If an unexpected error has occurred.
 GPA_LIB_DECL GpaStatus GpaBeginSession(GpaSessionId gpa_session_id);
+
+/// @brief Resets the session to a newly created state.
+///
+/// This includes disabling all counters and clearing all samples.
+///
+/// @ingroup gpa_session_handling
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+///
+/// @return The GPA result status of the operation.
+/// @retval kGpaStatusOk If the operation is successful.
+/// @retval kGpaStatusErrorNullPointer If any the gpa_session_id is NULL.
+/// @retval kGpaStatusErrorSessionNotFound The supplied session could not be found.
+GPA_LIB_DECL GpaStatus GpaResetSession(GpaSessionId gpa_session_id);
+
+/// @brief Aborts sampling with the currently enabled set of counters. Regardless of whether all passes have completed or any errors have occurred
+///
+/// @ingroup gpa_session_handling
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaAbortSession(GpaSessionId gpa_session_id);
+
+/// @defgroup gpa_session_interrogation GPA Session Interrogation and Configuration
+
+// The following functions can be called at any time after a session is created. The Get functions return
+// the current value (or default value if nothing has been changed) of the particular property. The Set
+// functions allow the client to change the default values. Once changed, all subsequent samples will use
+// the new setting.
+
+// SPM data may be collected on the command-list or the session level
+
+/// @brief Gets the mask of instruction types to be included in the SQTT data.
+///
+/// All subsequent SQTT samples will use this mask.
+/// Enabling detailed instruction information will lead to a much larger volume of SQTT data.
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [out] sqtt_instruction_mask The value which will hold the mask of instruction types to be included in the SQTT data.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttGetInstructionMask(GpaSessionId gpa_session_id, GpaSqttInstructionFlags* sqtt_instruction_mask);
+
+/// @brief Sets the mask of instruction types to be included in the SQTT data.
+///
+/// All subsequent SQTT samples will use this mask.
+/// Enabling detailed instruction information will lead to a much larger volume of SQTT data.
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] sqtt_instruction_mask The new value to set the mask to.
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttSetInstructionMask(GpaSessionId gpa_session_id, GpaSqttInstructionFlags sqtt_instruction_mask);
+
+/// @brief Gets the id of the compute unit which should generate the instruction level data.
+///
+/// All subsequent SQTT samples will use this compute unit id. Ignored if not collecting instruction-level information.
+///
+/// @ingroup Gpasession_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [out] sqtt_compute_unit_id The value which will hold the compute unit id.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttGetComputeUnitId(GpaSessionId gpa_session_id, GpaUInt32* sqtt_compute_unit_id);
+
+/// @brief Sets the id of the compute unit which should generate the instruction level data.
+///
+/// All subsequent SQTT samples will use this compute unit id. Ignored if not collecting instruction-level information.
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] sqtt_compute_unit_id The new value to set the compute unit id to.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttSetComputeUnitId(GpaSessionId gpa_session_id, GpaUInt32 sqtt_compute_unit_id);
+
+/// Begin collecting Session SQTT data
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] command_list the command list to begin collecting data
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttBegin(GpaSessionId gpa_session_id, void* command_list);
+
+/// End collecting SQTT data
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] command_list the command list to end collection of data
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttEnd(GpaSessionId gpa_session_id, void* command_list);
+
+/// Get SQTT sample result size
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [out] sample_result_size_in_bytes returns the number of bytes of data collected
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttGetSampleResultSize(GpaSessionId gpa_session_id, size_t* sample_result_size_in_bytes);
+
+/// Gets the SQTT sample results
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] sample_result_size_in_bytes size of the sqtt_results buffer
+/// @param [out] sqtt_results buffer to return results in
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSqttGetSampleResult(GpaSessionId gpa_session_id, size_t sample_result_size_in_bytes, void* sqtt_results);
+
+/// [Optional] Sets the sample interval for SPM data. The default is 4096.
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] interval sampling interval in clock cycles of the GPU shader clock domain (SCLK). This ranges from [32 - 4096]
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmSetSampleInterval(GpaSessionId gpa_session_id, GpaUInt32 interval);
+
+/// [Optional] Sets the duration of the SPM sample. The default is to assume that the sample is as large as possible.
+///
+/// If the duration is set, this allows the driver to optimize the amount of memory that is allocated for
+/// the SPM session. If the duration is not set, the recommended maximum amount of GPU memory will be
+/// allocated for SPM collection
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] nanosecond_duration duration in nanoseconds
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmSetDuration(GpaSessionId gpa_session_id, GpaUInt32 nanosecond_duration);
+
+/// Begin collecting SPM data
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] command_list the command list to begin collecting data
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmBegin(GpaSessionId gpa_session_id, void* command_list);
+
+/// End collecting SPM data
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] command_list the command list to end collecting data
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmEnd(GpaSessionId gpa_session_id, void* command_list);
+
+/// Get SPM sample result size
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param sample_result_size_in_bytes returns the number of bytes of data collected.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmGetSampleResultSize(GpaSessionId gpa_session_id, size_t* sample_result_size_in_bytes);
+
+/// Gets the SPM sample results
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] sample_result_size_in_bytes size of the spm_results buffer.
+/// @param [out] spm_results buffer of returned results.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmGetSampleResult(GpaSessionId gpa_session_id, size_t sample_result_size_in_bytes, void* spm_results);
+
+/// Calculate derived counters from collected SPM data
+///
+/// @ingroup gpa_session_interrogation
+///
+/// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
+/// @param [in] spm_data Collected SPM data.
+/// @param [in] derived_counter_count Number of counters that were enabled.
+/// @param [out] derived_counter_results Counter results of num_derived_counters * timestamps entries.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+GPA_LIB_DECL GpaStatus GpaSpmCalculateDerivedCounters(GpaSessionId gpa_session_id,
+                                                      GpaSpmData*  spm_data,
+                                                      GpaUInt32    derived_counter_count,
+                                                      GpaUInt64*   derived_counter_results);
 
 /// @brief Ends sampling with the currently enabled set of counters.
 ///
@@ -691,13 +915,13 @@ GPA_LIB_DECL GpaStatus GpaGetNumEnabledCounters(GpaSessionId gpa_session_id, Gpa
 
 /// @brief Gets the counter index for an enabled counter.
 ///
-/// This is meant to be used with GPA_GetNumEnabledCounters. Once you determine the number of enabled counters,
-/// you can use GPA_GetEnabledIndex to determine which counters are enabled.
+/// This is meant to be used with GpaGetNumEnabledCounters. Once you determine the number of enabled counters,
+/// you can use GpaGetEnabledIndex to determine which counters are enabled.
 ///
 /// @ingroup gpa_counter_scheduling
 ///
 /// @param [in] gpa_session_id Unique identifier of the session.
-/// @param [in] enabled_number The number of the enabled counter to get the counter index for. Must lie between 0 and (GPA_GetNumEnabledCounters result - 1).
+/// @param [in] enabled_number The number of the enabled counter to get the counter index for. Must lie between 0 and (GpaGetNumEnabledCounters result - 1).
 /// @param [out] enabled_counter_index The value that will hold the index of the counter upon successful execution.
 ///
 /// @return The GPA result status of the operation.
@@ -732,13 +956,13 @@ GPA_LIB_DECL GpaStatus GpaIsCounterEnabled(GpaSessionId gpa_session_id, GpaUInt3
 ///
 /// You will be unable to create samples on the specified command list before GpaBeginCommandList is called.
 /// Command list corresponds to ID3D12GraphicsCommandList in DirectX 12 and vkCommandBuffer in Vulkan.
-/// In OpenCL/OpenGL/DirectX 11, use GPA_NULL_COMMAND_LIST for the command_list parameter and kGpaCommandListNone for the command_list_type parameter.
+/// In OpenGL/DirectX 11, use GPA_NULL_COMMAND_LIST for the command_list parameter and kGpaCommandListNone for the command_list_type parameter.
 ///
 /// @ingroup gpa_sample_handling
 ///
 /// @param [in] gpa_session_id Unique identifier of the GPA Session Object.
 /// @param [in] pass_index 0-based index of the pass.
-/// @param [in] command_list The command list on which to begin sampling - ignored in OpenCL/OpenGL/DX11 applications.
+/// @param [in] command_list The command list on which to begin sampling - ignored in OpenGL/DX11 applications.
 /// @param [in] command_list_type Command list type.
 /// @param [out] gpa_command_list_id GPA-generated unique command list id.
 ///
@@ -759,11 +983,11 @@ GPA_LIB_DECL GpaStatus GpaBeginCommandList(GpaSessionId       gpa_session_id,
 
 /// @brief Ends command list for sampling.
 ///
-/// You will be unable to create samples on the specified command list after GPA_EndCommandList is called.
+/// You will be unable to create samples on the specified command list after GpaEndCommandList is called.
 ///
 /// @ingroup gpa_sample_handling
 ///
-/// @param [in] gpa_command_list_id The command list on which to end sampling - ignored in OpenCL/OpenGL applications.
+/// @param [in] gpa_command_list_id The command list on which to end sampling - ignored in OpenGL applications.
 ///
 /// @return The GPA result status of the operation.
 /// @retval kGpaStatusOk If the operation is successful.
@@ -776,14 +1000,14 @@ GPA_LIB_DECL GpaStatus GpaEndCommandList(GpaCommandListId gpa_command_list_id);
 /// @brief Begins a sample in a command list.
 ///
 /// A sample is a particular workload for which counters will be collected.
-/// If the owning session was created with GPA_SESSION_SAMPLE_TYPE_DISCRETE_COUNTER and
+/// If the owning session was created with kGpaSessionSampleTypeDiscreteCounter and
 /// one or more counters have been enabled, then those counters will be collected for this sample.
 /// Each sample must be associated with a GPA command list.
 /// Samples can be created by multiple threads provided no two threads are creating samples on same command list.
 /// You must provide a unique Id for every new sample. When performing multiple passes, a sample must exist in all passes.
 /// You may create as many samples as needed. However, nesting of samples is not allowed.
-/// Each sample must be wrapped in sequence of GPA_BeginSample/GPA_EndSample before starting another one.
-/// A sample can be started in one primary command list and continued/ended on another primary command list - See GPA_ContinueSampleOnCommandList.
+/// Each sample must be wrapped in sequence of GpaBeginSample/GpaEndSample before starting another one.
+/// A sample can be started in one primary command list and continued/ended on another primary command list - See GpaContinueSampleOnCommandList.
 ///
 /// @ingroup gpa_sample_handling
 ///
@@ -851,7 +1075,7 @@ GPA_LIB_DECL GpaStatus GpaContinueSampleOnCommandList(GpaUInt32 source_sample_id
 ///
 /// @ingroup gpa_sample_handling
 ///
-/// @param [in] secondary_gpa_command_list_id Aecondary command list where the secondary samples were created.
+/// @param [in] secondary_gpa_command_list_id Secondary command list where the secondary samples were created.
 /// @param [in] primary_gpa_command_list_id Primary command list to which the samples results should be copied. This should be the command list that executed the secondary command list.
 /// @param [in] number_of_samples Number of secondary samples.
 /// @param [in] new_sample_ids New sample ids on a primary command list.
@@ -934,7 +1158,7 @@ GPA_LIB_DECL GpaStatus GpaIsPassComplete(GpaSessionId gpa_session_id, GpaUInt32 
 /// After a sampling session results may be available immediately or take a certain amount of time to become available.
 /// This function allows you to determine when the results of a session can be read.
 /// The function does not block, permitting periodic polling.
-/// To block until a sample is ready use GPA_GetSampleResult instead.
+/// To block until a sample is ready use GpaGetSampleResult instead.
 ///
 /// @ingroup gpa_query_results
 ///
@@ -972,7 +1196,7 @@ GPA_LIB_DECL GpaStatus GpaGetSampleResultSize(GpaSessionId gpa_session_id, GpaUI
 
 /// @brief Gets the result data for a given sample.
 ///
-/// This function will block until results are ready. Use GPA_IsSessionComplete to check if results are ready.
+/// This function will block until results are ready. Use GpaIsSessionComplete to check if results are ready.
 ///
 /// @ingroup gpa_query_results
 ///

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_counters.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_counters.h
@@ -1,8 +1,8 @@
 //==============================================================================
-// Copyright (c) 2012-2021 Advanced Micro Devices, Inc. All rights reserved.
-/// \author AMD Developer Tools Team
-/// \file
-/// \brief  Interface to access to the available counters in GPUPerfAPI.
+// Copyright (c) 2012-2024 Advanced Micro Devices, Inc. All rights reserved.
+/// @author AMD Developer Tools Team
+/// @file
+/// @brief Interface to access to the available counters in GPUPerfAPI.
 //==============================================================================
 
 #ifndef GPU_PERF_API_GPU_PERF_API_COUNTERS_H_
@@ -17,7 +17,7 @@
 #include <stdbool.h>
 #endif
 
-/// macro to export public API functions
+/// Macro to export public API functions.
 #ifndef GPU_PERF_API_COUNTERS_DECL
 #ifdef _WIN32
 #ifdef __cplusplus
@@ -32,407 +32,438 @@
 
 #include "gpu_perf_api_types.h"
 
-/// Virtual Context ID opaque pointer type
+/// Virtual Context ID opaque pointer type.
 GPA_DEFINE_OBJECT(CounterContext)
 
-/// Gpa counter library major version
+/// GPA counter library major version.
 #define GPA_COUNTER_LIB_FUNC_TABLE_MAJOR_VERSION 3
 
-/// Gpa counter library minor version
+/// GPA counter library minor version.
 #define GPA_COUNTER_LIB_FUNC_TABLE_MINOR_VERSION (sizeof(struct _GpaCounterLibFuncTable))
 
-/// Gpa hardware blocks
+/// GPA hardware blocks.
 typedef enum
 {
-    kGpaHwBlockCpf = 0,  ///< The Gpa hardware block is CPF
-    kGpaHwBlockIa,       ///< The Gpa hardware block is IA
-    kGpaHwBlockVgt,      ///< The Gpa hardware block is VGT
-    kGpaHwBlockPa,       ///< The Gpa hardware block is PA
-    kGpaHwBlockSc,       ///< The Gpa hardware block is SC
-    kGpaHwBlockSpi,      ///< The Gpa hardware block is SPI
-    kGpaHwBlockSq,       ///< The Gpa hardware block is SQ
-    kGpaHwBlockSx,       ///< The Gpa hardware block is SX
-    kGpaHwBlockTa,       ///< The Gpa hardware block is TA
-    kGpaHwBlockTd,       ///< The Gpa hardware block is TD
-    kGpaHwBlockTcp,      ///< The Gpa hardware block is TCP
-    kGpaHwBlockTcc,      ///< The Gpa hardware block is TCC
-    kGpaHwBlockTca,      ///< The Gpa hardware block is TCA
-    kGpaHwBlockDb,       ///< The Gpa hardware block is DB
-    kGpaHwBlockCb,       ///< The Gpa hardware block is CB
-    kGpaHwBlockGds,      ///< The Gpa hardware block is GDS
-    kGpaHwBlockSrbm,     ///< The Gpa hardware block is SRBM
-    kGpaHwBlockGrbm,     ///< The Gpa hardware block is GRBM
-    kGpaHwBlockGrbmse,   ///< The Gpa hardware block is GRBMSE
-    kGpaHwBlockRlc,      ///< The Gpa hardware block is RLC
-    kGpaHwBlockDma,      ///< The Gpa hardware block is DMA
-    kGpaHwBlockMc,       ///< The Gpa hardware block is MC
-    kGpaHwBlockCpg,      ///< The Gpa hardware block is CPG
-    kGpaHwBlockCpc,      ///< The Gpa hardware block is CPC
-    kGpaHwBlockWd,       ///< The Gpa hardware block is WD
-    kGpaHwBlockTcs,      ///< The Gpa hardware block is TCS
-    kGpaHwBlockAtc,      ///< The Gpa hardware block is ATC
-    kGpaHwBlockAtcl2,    ///< The Gpa hardware block is ATCL2
-    kGpaHwBlockMcvml2,   ///< The Gpa hardware block is MCVML2
-    kGpaHwBlockEa,       ///< The Gpa hardware block is EA
-    kGpaHwBlockRpb,      ///< The Gpa hardware block is RPB
-    kGpaHwBlockRmi,      ///< The Gpa hardware block is RMI
-    kGpaHwBlockUmcch,    ///< The Gpa hardware block is UMCCH
-    kGpaHwBlockGe,       ///< The Gpa hardware block is GE
-    kGpaHwBlockGl1A,     ///< The Gpa hardware block is GL1A
-    kGpaHwBlockGl1C,     ///< The Gpa hardware block is GL1C
-    kGpaHwBlockGl1Cg,    ///< The Gpa hardware block is GL1CG
-    kGpaHwBlockGl2A,     ///< The Gpa hardware block is GL2A
-    kGpaHwBlockGl2C,     ///< The Gpa hardware block is GL2C
-    kGpaHwBlockCha,      ///< The Gpa hardware block is CHA
-    kGpaHwBlockChc,      ///< The Gpa hardware block is CHC
-    kGpaHwBlockChcg,     ///< The Gpa hardware block is CHCG
-    kGpaHwBlockGus,      ///< The Gpa hardware block is GUS
-    kGpaHwBlockGcr,      ///< The Gpa hardware block is GCR
-    kGpaHwBlockPh,       ///< The Gpa hardware block is PH
-    kGpaHwBlockUtcl1,    ///< The Gpa hardware block is UTCL1
-    kGpaHwBlockGedist,   ///< The Gpa hardware block is GEDIST
-    kGpaHwBlockGese,     ///< The Gpa hardware block is GESE
-    kGpaHwBlockDfmall,   ///< The Gpa hardware block is DFMALL
-    kGpaHwBlockCount,    ///< Count
+    kGpaHwBlockCpf = 0,  ///< The GPA hardware block is CPF.
+    kGpaHwBlockIa,       ///< The GPA hardware block is IA.
+    kGpaHwBlockVgt,      ///< The GPA hardware block is VGT.
+    kGpaHwBlockPa,       ///< The GPA hardware block is PA.
+    kGpaHwBlockSc,       ///< The GPA hardware block is SC.
+    kGpaHwBlockSpi,      ///< The GPA hardware block is SPI.
+    kGpaHwBlockSq,       ///< The GPA hardware block is SQ.
+    kGpaHwBlockSx,       ///< The GPA hardware block is SX.
+    kGpaHwBlockTa,       ///< The GPA hardware block is TA.
+    kGpaHwBlockTd,       ///< The GPA hardware block is TD.
+    kGpaHwBlockTcp,      ///< The GPA hardware block is TCP.
+    kGpaHwBlockTcc,      ///< The GPA hardware block is TCC.
+    kGpaHwBlockTca,      ///< The GPA hardware block is TCA.
+    kGpaHwBlockDb,       ///< The GPA hardware block is DB.
+    kGpaHwBlockCb,       ///< The GPA hardware block is CB.
+    kGpaHwBlockGds,      ///< The GPA hardware block is GDS.
+    kGpaHwBlockSrbm,     ///< The GPA hardware block is SRBM.
+    kGpaHwBlockGrbm,     ///< The GPA hardware block is GRBM.
+    kGpaHwBlockGrbmse,   ///< The GPA hardware block is GRBMSE.
+    kGpaHwBlockRlc,      ///< The GPA hardware block is RLC.
+    kGpaHwBlockDma,      ///< The GPA hardware block is DMA.
+    kGpaHwBlockMc,       ///< The GPA hardware block is MC.
+    kGpaHwBlockCpg,      ///< The GPA hardware block is CPG.
+    kGpaHwBlockCpc,      ///< The GPA hardware block is CPC.
+    kGpaHwBlockWd,       ///< The GPA hardware block is WD.
+    kGpaHwBlockTcs,      ///< The GPA hardware block is TCS.
+    kGpaHwBlockAtc,      ///< The GPA hardware block is ATC.
+    kGpaHwBlockAtcl2,    ///< The GPA hardware block is ATCL2.
+    kGpaHwBlockMcvml2,   ///< The GPA hardware block is MCVML2.
+    kGpaHwBlockEa,       ///< The GPA hardware block is EA.
+    kGpaHwBlockRpb,      ///< The GPA hardware block is RPB.
+    kGpaHwBlockRmi,      ///< The GPA hardware block is RMI.
+    kGpaHwBlockUmcch,    ///< The GPA hardware block is UMCCH.
+    kGpaHwBlockGe,       ///< The GPA hardware block is GE.
+    kGpaHwBlockGl1A,     ///< The GPA hardware block is GL1A.
+    kGpaHwBlockGl1C,     ///< The GPA hardware block is GL1C.
+    kGpaHwBlockGl1Cg,    ///< The GPA hardware block is GL1CG.
+    kGpaHwBlockGl2A,     ///< The GPA hardware block is GL2A.
+    kGpaHwBlockGl2C,     ///< The GPA hardware block is GL2C.
+    kGpaHwBlockCha,      ///< The GPA hardware block is CHA.
+    kGpaHwBlockChc,      ///< The GPA hardware block is CHC.
+    kGpaHwBlockChcg,     ///< The GPA hardware block is CHCG.
+    kGpaHwBlockGus,      ///< The GPA hardware block is GUS.
+    kGpaHwBlockGcr,      ///< The GPA hardware block is GCR.
+    kGpaHwBlockPh,       ///< The GPA hardware block is PH.
+    kGpaHwBlockUtcl1,    ///< The GPA hardware block is UTCL1.
+    kGpaHwBlockGedist,   ///< The GPA hardware block is GEDIST.
+    kGpaHwBlockGese,     ///< The GPA hardware block is GESE.
+    kGpaHwBlockDfmall,   ///< The GPA hardware block is DFMALL.
+    kGpaHwBlockSqWgp,    ///< The GPA hardware block is SQWGP.
+    kGpaHwBlockPc,       ///< The GPA hardware block is PC.
+    kGpaHwBlockGl1XA,    ///< The GPA hardware block is GL1XA.
+    kGpaHwBlockGl1XC,    ///< The GPA hardware block is GL1XC.
+    kGpaHwBlockWgs,      ///< The GPA hardware block is WGS.
+    kGpaHwBlockEaCpwd,   ///< The GPA hardware block is EA_CPWD.
+    kGpaHwBlockEaSe,     ///< The GPA hardware block is EA_SE.
+    kGpaHwBlockCount,    ///< Count.
 } GpaHwBlock;
 
-/// Gpa shader masks
+/// GPA shader masks.
 typedef enum
 {
-    kGpaShaderMaskPs,   ///< The Gpa PS shader mask
-    kGpaShaderMaskVs,   ///< The Gpa VS shader mask
-    kGpaShaderMaskGs,   ///< The Gpa GS shader mask
-    kGpaShaderMaskEs,   ///< The Gpa ES shader mask
-    kGpaShaderMaskHs,   ///< The Gpa HS shader mask
-    kGpaShaderMaskLs,   ///< The Gpa LS shader mask
-    kGpaShaderMaskCs,   ///< The Gpa CS shader mask
-    kGpaShaderMaskAll,  ///< The Gpa all shader mask
+    kGpaShaderMaskPs,   ///< The GPA PS shader mask.
+    kGpaShaderMaskVs,   ///< The GPA VS shader mask.
+    kGpaShaderMaskGs,   ///< The GPA GS shader mask.
+    kGpaShaderMaskEs,   ///< The GPA ES shader mask.
+    kGpaShaderMaskHs,   ///< The GPA HS shader mask.
+    kGpaShaderMaskLs,   ///< The GPA LS shader mask.
+    kGpaShaderMaskCs,   ///< The GPA CS shader mask.
+    kGpaShaderMaskAll,  ///< The GPA all shader mask.
 } GpaShaderMask;
 
-/// Gpa hardware attribute types
+/// GPA hardware attribute types.
 typedef enum
 {
-    kGpaHardwareAttributeNumShaderEngines,        ///< number of shader engines
-    kGpaHardwareAttributeNumShaderArrays,         ///< number of shader arrays
-    kGpaHardwareAttributeNumSimds,                ///< number of simds
-    kGpaHardwareAttributeNumComputeUnits,         ///< number of compute units
-    kGpaHardwareAttributeNumRenderBackends,       ///< number of render backends
-    kGpaHardwareAttributeClocksPerPrimitive,      ///< clocks per primitive
-    kGpaHardwareAttributeNumPrimitivePipes,       ///< number of primitive pipes
-    kGpaHardwareAttributeTimestampFrequency,      ///< timestamp frequency
-    kGpaHardwareAttributePeakVerticesPerClock,    ///< peak vertices per clock
-    kGpaHardwareAttributePeakPrimitivesPerClock,  ///< peak primitives per clock
-    kGpaHardwareAttributePeakPixelsPerClock       ///< peak pixels per clocks
+    kGpaHardwareAttributeNumShaderEngines,        ///< Number of shader engines.
+    kGpaHardwareAttributeNumShaderArrays,         ///< Number of shader arrays.
+    kGpaHardwareAttributeNumSimds,                ///< Number of simds.
+    kGpaHardwareAttributeNumComputeUnits,         ///< Number of compute units.
+    kGpaHardwareAttributeNumRenderBackends,       ///< Number of render backends.
+    kGpaHardwareAttributeClocksPerPrimitive,      ///< Clocks per primitive.
+    kGpaHardwareAttributeNumPrimitivePipes,       ///< Number of primitive pipes.
+    kGpaHardwareAttributeTimestampFrequency,      ///< Timestamp frequency.
+    kGpaHardwareAttributePeakVerticesPerClock,    ///< Peak vertices per clock.
+    kGpaHardwareAttributePeakPrimitivesPerClock,  ///< Peak primitives per clock.
+    kGpaHardwareAttributePeakPixelsPerClock       ///< Peak pixels per clocks.
 } GpaHardwareAttributeType;
 
-/// Gpa Hardware attribute
+/// GPA Hardware attribute.
 typedef struct _GpaHardwareAttribute
 {
-    GpaHardwareAttributeType gpa_hardware_attribute_type;   ///< gpa hardware attribute type
-    GpaUInt32                gpa_hardware_attribute_value;  ///< gpa hardware attribute value
+    GpaHardwareAttributeType gpa_hardware_attribute_type;   ///< GPA hardware attribute type.
+    GpaUInt32                gpa_hardware_attribute_value;  ///< GPA hardware attribute value.
 } GpaHardwareAttribute;
 
-/// Gpa counter context hardware info
+/// GPA counter context hardware info.
 typedef struct _GpaCounterContextHardwareInfo
 {
-    GpaUInt32 vendor_id;    ///< vendor Id
-    GpaUInt32 device_id;    ///< device Id
-    GpaUInt32 revision_id;  ///< revision Id
+    GpaUInt32 vendor_id;    ///< Vendor Id.
+    GpaUInt32 device_id;    ///< Device Id.
+    GpaUInt32 revision_id;  ///< Revision Id.
 
-    GpaHardwareAttribute* gpa_hardware_attributes;       ///< pointer to array of hardware attributes
-    GpaUInt32             gpa_hardware_attribute_count;  ///< number of hardware attributes
+    GpaHardwareAttribute* gpa_hardware_attributes;       ///< Pointer to array of hardware attributes.
+    GpaUInt32             gpa_hardware_attribute_count;  ///< Number of hardware attributes.
 
 } GpaCounterContextHardwareInfo;
 
-/// Hardware counter info
+/// Hardware counter info.
 typedef struct _GpaHwCounter
 {
-    bool is_timing_block;  ///< flag indicating time based derived counter
+    bool is_timing_block;  ///< Flag indicating time based derived counter.
     union
     {
         union
         {
-            GpaUInt32 gpu_time_bottom_to_bottom_duration;  ///< index of gpu_time_bottom_to_bottom_duration counter
-            GpaUInt32 gpu_time_bottom_to_bottom_start;     ///< index of gpu_time_bottom_to_bottom_duration counter
-            GpaUInt32 gpu_time_bottom_to_bottom_end;       ///< index of gpu_time_bottom_to_bottom_duration counter
-            GpaUInt32 gpu_time_top_to_bottom_duration;     ///< index of gpu_time_top_to_bottom_duration counter
-            GpaUInt32 gpu_time_top_to_bottom_start;        ///< index of gpu_time_top_to_bottom_start counter
-            GpaUInt32 gpu_time_top_to_bottom_end;          ///< index of gpu_time_top_to_bottom_end counter
+            GpaUInt32 gpu_time_bottom_to_bottom_duration;  ///< Index of gpu_time_bottom_to_bottom_duration counter.
+            GpaUInt32 gpu_time_bottom_to_bottom_start;     ///< Index of gpu_time_bottom_to_bottom_duration counter.
+            GpaUInt32 gpu_time_bottom_to_bottom_end;       ///< Index of gpu_time_bottom_to_bottom_duration counter.
+            GpaUInt32 gpu_time_top_to_bottom_duration;     ///< Index of gpu_time_top_to_bottom_duration counter.
+            GpaUInt32 gpu_time_top_to_bottom_start;        ///< Index of gpu_time_top_to_bottom_start counter.
+            GpaUInt32 gpu_time_top_to_bottom_end;          ///< Index of gpu_time_top_to_bottom_end counter.
         };
 
         struct
         {
-            GpaHwBlock    gpa_hw_block;           ///< Gpa hardware block
-            GpaUInt32     gpa_hw_block_instance;  ///< Gpa hardware block 0-based instance index
-            GpaUInt32     gpa_hw_block_event_id;  ///< Gpa hardware block 0-based event id
-            GpaShaderMask gpa_shader_mask;        ///< Gpa shader mask, only used if SQ block is queried
+            GpaHwBlock    gpa_hw_block;           ///< GPA hardware block.
+            GpaUInt32     gpa_hw_block_instance;  ///< GPA hardware block 0-based instance index.
+            GpaUInt32     gpa_hw_block_event_id;  ///< GPA hardware block 0-based event id.
+            GpaShaderMask gpa_shader_mask;        ///< GPA shader mask, only used if SQ block is queried.
         };
     };
 
 } GpaHwCounter;
 
-/// Gpa derived counter info
+/// GPA derived counter info.
 typedef struct _GpaDerivedCounterInfo
 {
-    GpaHwCounter* gpa_hw_counters;       ///< hardware counters
-    GpaUInt32     gpa_hw_counter_count;  ///< number of hardware counter
-    GpaUsageType  counter_usage_type;    ///< usage of the derived counter
+    GpaHwCounter* gpa_hw_counters;       ///< Hardware counters.
+    GpaUInt32     gpa_hw_counter_count;  ///< Number of hardware counter.
+    GpaUsageType  counter_usage_type;    ///< Usage of the derived counter.
 
 } GpaDerivedCounterInfo;
 
-/// Gpa counter info -- can be a derived counter or a hardware counter
+/// GPA counter info -- can be a derived counter or a hardware counter.
 typedef struct _GpaCounterInfo
 {
-    bool is_derived_counter;  ///< flag indicating this is a derived counter
+    bool is_derived_counter;  ///< Flag indicating this is a derived counter.
     union
     {
-        GpaDerivedCounterInfo* gpa_derived_counter;  ///< derived counter
-        GpaHwCounter*          gpa_hw_counter;       ///< hardware counter
+        GpaDerivedCounterInfo* gpa_derived_counter;  ///< Derived counter.
+        GpaHwCounter*          gpa_hw_counter;       ///< Hardware counter.
     };
 } GpaCounterInfo;
 
-/// Gpa counter parameter
+/// GPA counter parameter.
 typedef struct _GpaCounterParam
 {
-    bool is_derived_counter;  ///< flag indicating derived counter
+    bool is_derived_counter;  ///< Flag indicating derived counter.
     union
     {
-        const char*  derived_counter_name;  ///< derived counter name
-        GpaHwCounter gpa_hw_counter;        ///< hardware counter
+        const char*  derived_counter_name;  ///< Derived counter name.
+        GpaHwCounter gpa_hw_counter;        ///< Hardware counter.
     };
 } GpaCounterParam;
 
-///  Gpa counters in a pass
+/// GPA counters in a pass.
 typedef struct _GpaPassCounter
 {
-    GpaUInt32  pass_index;       ///< pass index
-    GpaUInt32  counter_count;    ///< number of counters
-    GpaUInt32* counter_indices;  ///< indices of the counters
+    GpaUInt32  pass_index;       ///< Pass index.
+    GpaUInt32  counter_count;    ///< Number of counters.
+    GpaUInt32* counter_indices;  ///< Indices of the counters.
 } GpaPassCounter;
 
-/// \brief Gets the Gpa Counter lib version
+/// @brief Gets the GPA Counter lib version.
 ///
-/// \param[out] major_version The value that will hold the major version of GPA upon successful execution.
-/// \param[out] minor_version The value that will hold the minor version of GPA upon successful execution.
-/// \param[out] build_number The value that will hold the build number of GPA upon successful execution.
-/// \param[out] update_version The value that will hold the update version of GPA upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [out] major_version The value that will hold the major version of GPA upon successful execution.
+/// @param [out] minor_version The value that will hold the minor version of GPA upon successful execution.
+/// @param [out] build_number The value that will hold the build number of GPA upon successful execution.
+/// @param [out] update_version The value that will hold the update version of GPA upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetVersion(GpaUInt32* major_version,
                                                              GpaUInt32* minor_version,
                                                              GpaUInt32* build_number,
                                                              GpaUInt32* update_version);
 
-/// typedef for GpaCounterLibGetVersion function pointer
+/// Typedef for GpaCounterLibGetVersion function pointer.
 typedef GpaStatus (*GpaCounterLibGetVersionPtrType)(GpaUInt32*, GpaUInt32*, GpaUInt32*, GpaUInt32*);
 
-/// \brief Gets the Gpa counter library function table.
+/// @brief Gets the GPA counter library function table.
 ///
-/// \param[out] gpa_counter_lib_function_table pointer to the Gpa counter library function table.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [out] gpa_counter_lib_function_table pointer to the GPA counter library function table.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetFuncTable(void* gpa_counter_lib_function_table);
 
-/// typedef for GpaCounterLibGetFuncTable function pointer
+/// Typedef for GpaCounterLibGetFuncTable function pointer.
 typedef GpaStatus (*GpaCounterLibGetFuncTablePtrType)(void*);
 
-/// \brief Creates a virtual context to interrogate the counter information.
+/// @brief Creates a virtual context to interrogate the counter information.
 ///
-/// \param[in] api the api whose available counters are requested.
-/// \param[in] gpa_counter_context_hardware_info counter context hardware info.
-/// \param[in] context_flags Flags used to initialize the context. Should be a combination of GPA_OpenContext_Bits.
-/// \param[in] generate_asic_specific_counters Flag that indicates whether the counters should be ASIC specific, if available.
-/// \param[out] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] api The api whose available counters are requested.
+/// @param [in] sample_type The type of sample to be collected.
+/// @param [in] gpa_counter_context_hardware_info counter context hardware info.
+/// @param [in] context_flags Flags used to initialize the context. Should be a combination of GpaOpenContextBits.
+/// @param [out] gpa_virtual_context Unique identifier of the opened virtual context.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @retval kGpaStatusErrorNullPointer If the supplied gpa_virtual_context is a nullptr.
+/// @retval kGpaStatusErrorInvalidParameter If any value other than 1 (true) is passed in for generate_asic_specific_counters_deprecated,
+///         or if the context_flags specified would result in zero counters being exposed.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibOpenCounterContext(GpaApiType                    api,
+                                                                     GpaSessionSampleType          sample_type,
                                                                      GpaCounterContextHardwareInfo gpa_counter_context_hardware_info,
                                                                      GpaOpenContextFlags           context_flags,
-                                                                     GpaUInt8                      generate_asic_specific_counters,
                                                                      GpaCounterContext*            gpa_virtual_context);
 
-/// typedef for GpaCounterLibOpenCounterContext function pointer
-typedef GpaStatus (*GpaCounterLibOpenCounterContextPtrType)(GpaApiType, GpaCounterContextHardwareInfo, GpaOpenContextFlags, GpaUInt8, GpaCounterContext*);
+/// typedef for GpaCounterLibOpenCounterContext function pointer.
+typedef GpaStatus (
+    *GpaCounterLibOpenCounterContextPtrType)(GpaApiType, GpaSessionSampleType, GpaCounterContextHardwareInfo, GpaOpenContextFlags, GpaCounterContext*);
 
-/// \brief Closes the specified context, which ends access to GPU performance counters.
+/// @brief Closes the specified context, which ends access to GPU performance counters.
 ///
 /// Counter functions should not be called again until the counters are reopened with GpaCounterLib_OpenCounterContext.
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+///
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibCloseCounterContext(const GpaCounterContext gpa_virtual_context);
 
-/// typedef for GpaCounterLibCloseCounterContextPtrType function pointer
+/// Typedef for GpaCounterLibCloseCounterContextPtrType function pointer.
 typedef GpaStatus (*GpaCounterLibCloseCounterContextPtrType)(const GpaCounterContext);
 
-/// \brief Gets the number of counters available.
+/// @brief Gets the number of counters available.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[out] gpa_counter_count The value which will hold the count upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [out] gpa_counter_count The value which will hold the count upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetNumCounters(const GpaCounterContext gpa_virtual_context, GpaUInt32* gpa_counter_count);
 
-/// typedef for GpaCounterLibGetNumCountersPtr function pointer
+/// Typedef for GpaCounterLibGetNumCountersPtr function pointer.
 typedef GpaStatus (*GpaCounterLibGetNumCountersPtrType)(const GpaCounterContext, GpaUInt32*);
 
-/// \brief Gets the name of the specified counter.
+/// @brief Gets the name of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The derived_gpa_counter_index of the counter whose name is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_name The address which will hold the name upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The derived_gpa_counter_index of the counter whose name is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_name The address which will hold the name upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterName(const GpaCounterContext gpa_virtual_context,
                                                                  GpaUInt32               gpa_counter_index,
                                                                  const char**            gpa_counter_name);
 
-/// typedef for GpaCounterLibGetCounterName function pointer
+/// Typedef for GpaCounterLibGetCounterName function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterNamePtrType)(const GpaCounterContext, GpaUInt32, const char**);
 
-/// \brief Gets index of a counter given its name (case insensitive).
+/// @brief Gets index of a counter given its name (case insensitive).
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the session.
-/// \param[in] gpa_counter_info The name of the counter whose index is needed.
-/// \param[out] gpa_counter_index The address which will hold the index upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the session.
+/// @param [in] gpa_counter_info The name of the counter whose index is needed.
+/// @param [out] gpa_counter_index The address which will hold the index upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @retval kGpaStatusErrorNullPointer if the gpa_counter_info or gpa_counter_index is null, or if the gpa_counter_info
+///         indicates that it is a derived counter, but the derived counter name is null.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterIndex(const GpaCounterContext gpa_virtual_context,
                                                                   const GpaCounterParam*  gpa_counter_info,
                                                                   GpaUInt32*              gpa_counter_index);
 
-/// typedef for GpaCounterLibGetCounterIndex function pointer
+/// Typedef for GpaCounterLibGetCounterIndex function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterIndexPtrType)(const GpaCounterContext, const GpaCounterParam*, GpaUInt32*);
 
-/// \brief Gets the group of the specified counter.
+/// @brief Gets the group of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose group is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_group The address which will hold the group string upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose group is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_group The address which will hold the group string upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterGroup(const GpaCounterContext gpa_virtual_context,
                                                                   GpaUInt32               gpa_counter_index,
                                                                   const char**            gpa_counter_group);
 
-/// typedef for GpaCounterLibGetCounterGroup function pointer
+/// Typedef for GpaCounterLibGetCounterGroup function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterGroupPtrType)(const GpaCounterContext, GpaUInt32, const char**);
 
-/// \brief Gets the description of the specified counter.
+/// @brief Gets the description of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose description is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_description The address which will hold the description upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose description is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_description The address which will hold the description upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterDescription(const GpaCounterContext gpa_virtual_context,
                                                                         GpaUInt32               gpa_counter_index,
                                                                         const char**            gpa_counter_description);
 
-/// typedef for GpaCounterLibGetCounterDescription function pointer
+/// Typedef for GpaCounterLibGetCounterDescription function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterDescriptionPtrType)(const GpaCounterContext, GpaUInt32, const char**);
 
-/// \brief Gets the data type of the specified counter.
+/// @brief Gets the data type of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose data type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_data_type The value which will hold the counter data type upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose data type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_data_type The value which will hold the counter data type upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterDataType(const GpaCounterContext gpa_virtual_context,
                                                                      GpaUInt32               gpa_counter_index,
                                                                      GpaDataType*            gpa_counter_data_type);
 
-/// typedef for GpaCounterLibGetCounterDataType function pointer
+/// Typedef for GpaCounterLibGetCounterDataType function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterDataTypePtrType)(const GpaCounterContext, GpaUInt32, GpaDataType*);
 
-/// \brief Gets the usage type of the specified counter.
+/// @brief Gets the usage type of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose usage type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_usage_type The value which will hold the counter usage type upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose usage type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_usage_type The value which will hold the counter usage type upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterUsageType(const GpaCounterContext gpa_virtual_context,
                                                                       GpaUInt32               gpa_counter_index,
                                                                       GpaUsageType*           gpa_counter_usage_type);
 
-/// typedef for GpaCounterLibGetCounterUsageType function pointer
+/// Typedef for GpaCounterLibGetCounterUsageType function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterUsageTypePtrType)(const GpaCounterContext, GpaUInt32, GpaUsageType*);
 
-/// \brief Gets the UUID of the specified counter.
+/// @brief Gets the UUID of the specified counter.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose UUID is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_uuid The value which will hold the counter UUID upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose UUID is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_uuid The value which will hold the counter UUID upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterUuid(const GpaCounterContext gpa_virtual_context,
                                                                  GpaUInt32               gpa_counter_index,
                                                                  GpaUuid*                gpa_counter_uuid);
 
-/// typedef for GpaCounterLibGetCounterUuid function pointer
+/// Typedef for GpaCounterLibGetCounterUuid function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterUuidPtrType)(const GpaCounterContext, GpaUInt32, GpaUuid*);
 
-/// \brief Gets the supported sample type of the specified counter.
+/// @brief Gets the supported sample type of the specified counter.
 ///
 /// Currently, only a single counter type (discrete) is supported
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index The index of the counter whose sample type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
-/// \param[out] gpa_counter_sample_type The value which will hold the counter's supported sample type upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index The index of the counter whose sample type is needed. Must lie between 0 and (GpaGetNumCounters result - 1).
+/// @param [out] gpa_counter_sample_type The value which will hold the counter's supported sample type upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterSampleType(const GpaCounterContext gpa_virtual_context,
                                                                        GpaUInt32               gpa_counter_index,
                                                                        GpaCounterSampleType*   gpa_counter_sample_type);
 
-/// typedef for GpaCounterLibGetCounterSampleType function pointer
+/// Typedef for GpaCounterLibGetCounterSampleType function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterSampleTypePtrType)(const GpaCounterContext, GpaUInt32, GpaCounterSampleType*);
 
-/// \brief Get the counter info.
+/// @brief Get the counter info.
 ///
 /// This can be used only if GpaOpenContextHidePublicCountersBit flag is not used while opening the virtual context.
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_index index of the counter.
-/// \param[out] gpa_counter_info counter information.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful. GPA_STATUS_ERROR_FAILED is returned if whitelist/hardware counter index is passed.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_index index of the counter.
+/// @param [out] gpa_counter_info counter information.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful. GPA_STATUS_ERROR_FAILED is returned if whitelist/hardware counter index is passed.
 
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCounterInfo(const GpaCounterContext gpa_virtual_context,
                                                                  GpaUInt32               gpa_counter_index,
                                                                  const GpaCounterInfo**  gpa_counter_info);
 
-/// typedef for GpaCounterLibGetCounterInfo function pointer
+/// Typedef for GpaCounterLibGetCounterInfo function pointer.
 typedef GpaStatus (*GpaCounterLibGetCounterInfoPtrType)(const GpaCounterContext, GpaUInt32, const GpaCounterInfo**);
 
-/// \brief Computes the derived counter result.
+/// @brief Computes the derived counter result.
 ///
 /// This can be used only if GpaOpenContextHidePublicCountersBit flag is not used while opening the virtual context.
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_derived_counter_index index of the derived counter.
-/// \param[in] gpa_hw_counter_result hardware counter data
-/// \param[in] gpa_hw_counter_result_count number of hardware counter data
-/// \param[out] gpa_derived_counter_result computed derive counter result.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful. GPA_STATUS_ERROR_FAILED is returned if whitelist/hardware counter index is passed.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_derived_counter_index index of the derived counter.
+/// @param [in] gpa_hw_counter_result hardware counter data
+/// @param [in] gpa_hw_counter_result_count number of hardware counter data.
+/// @param [out] gpa_derived_counter_result computed derive counter result.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful. GPA_STATUS_ERROR_FAILED is returned if whitelist/hardware counter index is passed.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibComputeDerivedCounterResult(const GpaCounterContext gpa_virtual_context,
                                                                               GpaUInt32               gpa_derived_counter_index,
                                                                               const GpaUInt64*        gpa_hw_counter_result,
                                                                               GpaUInt32               gpa_hw_counter_result_count,
                                                                               GpaFloat64*             gpa_derived_counter_result);
 
-/// typedef for GpaCounterLibComputeDerivedCounterResult function pointer
+/// Typedef for GpaCounterLibComputeDerivedCounterResult function pointer.
 typedef GpaStatus (*GpaCounterLibComputeDerivedCounterResultPtrType)(const GpaCounterContext, GpaUInt32, const GpaUInt64*, GpaUInt32, GpaFloat64*);
 
-/// \brief Gets the number of passes required for the set of counters.
+/// @brief Gets the number of passes required for the set of counters.
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_indices indices of the counters to be enabled.
-/// \param[in] gpa_counter_count number of counters.
-/// \param[out] number_of_pass_req The value which will hold the number of required passes upon successful execution.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_indices indices of the counters to be enabled.
+/// @param [in] gpa_counter_count number of counters.
+/// @param [out] number_of_pass_req The value which will hold the number of required passes upon successful execution.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetPassCount(const GpaCounterContext gpa_virtual_context,
                                                                const GpaUInt32*        gpa_counter_indices,
                                                                GpaUInt32               gpa_counter_count,
                                                                GpaUInt32*              number_of_pass_req);
 
-/// typedef for GpaCounterLibGetPassCount function pointer
+/// Typedef for GpaCounterLibGetPassCount function pointer.
 typedef GpaStatus (*GpaCounterLibGetPassCountPtrType)(const GpaCounterContext, const GpaUInt32*, GpaUInt32, GpaUInt32*);
 
-/// \brief For a given set of counters, get information on how the corresponding hardware counters are scheduled into passes
+/// @brief For a given set of counters, get information on how the corresponding hardware counters are scheduled into passes
 ///
-/// \param[in] gpa_virtual_context Unique identifier of the opened virtual context.
-/// \param[in] gpa_counter_count number of counters.
-/// \param[in] gpa_counter_indices indices of the counters to be enabled.
-/// \param[in, out] pass_count contains number of passes required for given set of counters if counter_by_pass_list is null, otherwise represents size of the input counter_by_pass_list array.
-/// \param[out] counter_by_pass_list list containing number of counters in each pass. Use this to allocate memory for the counter values.
-/// \param[out] gpa_pass_counters list containing number of counters in each pass. Use this to allocate memory for the counter values.
-/// \return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
+/// @param [in] gpa_virtual_context Unique identifier of the opened virtual context.
+/// @param [in] gpa_counter_count number of counters.
+/// @param [in] gpa_counter_indices indices of the counters to be enabled.
+/// @param [in, out] pass_count contains number of passes required for given set of counters if counter_by_pass_list is null, otherwise represents size of the input counter_by_pass_list array.
+/// @param [out] counter_by_pass_list list containing number of counters in each pass. Use this to allocate memory for the counter values.
+/// @param [out] gpa_pass_counters list containing number of counters in each pass. Use this to allocate memory for the counter values.
+///
+/// @return The GPA result status of the operation. kGpaStatusOk is returned if the operation is successful.
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCountersByPass(const GpaCounterContext gpa_virtual_context,
                                                                     GpaUInt32               gpa_counter_count,
                                                                     const GpaUInt32*        gpa_counter_indices,
@@ -440,9 +471,8 @@ GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibGetCountersByPass(const GpaCou
                                                                     GpaUInt32*              counter_by_pass_list,
                                                                     GpaPassCounter*         gpa_pass_counters);
 
-/// typedef for GpaCounterLibGetPassCount function pointer
-typedef GpaStatus (
-    *GpaCounterLibGetCountersByPassPtrType)(const GpaCounterContext, GpaUInt32, const GpaUInt32*, GpaUInt32*, GpaUInt32*, GpaPassCounter*);
+/// Typedef for GpaCounterLibGetPassCount function pointer.
+typedef GpaStatus (*GpaCounterLibGetCountersByPassPtrType)(const GpaCounterContext, GpaUInt32, const GpaUInt32*, GpaUInt32*, GpaUInt32*, GpaPassCounter*);
 
 #define GPA_COUNTER_LIB_FUNC(X)                 \
     X(GpaCounterLibGetVersion)                  \
@@ -463,7 +493,7 @@ typedef GpaStatus (
     X(GpaCounterLibGetPassCount)                \
     X(GpaCounterLibGetCountersByPass)
 
-/// Gpa counter library function table
+/// GPA counter library function table.
 typedef struct _GpaCounterLibFuncTable
 {
     GpaUInt32 gpa_counter_lib_major_version;

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_function_types.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_function_types.h
@@ -1,5 +1,5 @@
 //==============================================================================
-// Copyright (c) 2010-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2010-2024 Advanced Micro Devices, Inc. All rights reserved.
 /// @author AMD Developer Tools Team
 /// @file
 /// @brief  This file defines function types to make it easier to dynamically load
@@ -46,32 +46,38 @@ typedef GpaStatus (*GpaGetDeviceAndRevisionIdPtrType)(GpaContextId, GpaUInt32*, 
 /// Typedef for a function pointer for GpaGetDeviceName.
 typedef GpaStatus (*GpaGetDeviceNamePtrType)(GpaContextId, const char**);
 
+/// Typedef for a function pointer for GpaUpdateDeviceInformation
+typedef GpaStatus (*GpaUpdateDeviceInformationPtrType)(GpaContextId, GpaUInt32, GpaUInt32, GpaUInt32, GpaUInt32);
+
+/// Typedef for a function pointer for GpaGetDeviceGeneration.
+typedef GpaStatus (*GpaGetDeviceGenerationPtrType)(GpaContextId, GpaHwGeneration*);
+
 /// Typedef for a function pointer for GpaGetNumCounters.
-typedef GpaStatus (*GpaGetNumCountersPtrType)(GpaContextId, GpaUInt32*);
+typedef GpaStatus (*GpaGetNumCountersPtrType)(GpaSessionId, GpaUInt32*);
 
 /// Typedef for a function pointer for GpaGetCounterName.
-typedef GpaStatus (*GpaGetCounterNamePtrType)(GpaContextId, GpaUInt32, const char**);
+typedef GpaStatus (*GpaGetCounterNamePtrType)(GpaSessionId, GpaUInt32, const char**);
 
 /// Typedef for a function pointer for GpaGetCounterIndex.
-typedef GpaStatus (*GpaGetCounterIndexPtrType)(GpaContextId, const char*, GpaUInt32*);
+typedef GpaStatus (*GpaGetCounterIndexPtrType)(GpaSessionId, const char*, GpaUInt32*);
 
 /// Typedef for a function pointer for GpaGetCounterGroup.
-typedef GpaStatus (*GpaGetCounterGroupPtrType)(GpaContextId, GpaUInt32, const char**);
+typedef GpaStatus (*GpaGetCounterGroupPtrType)(GpaSessionId, GpaUInt32, const char**);
 
 /// Typedef for a function pointer for GpaGetCounterDescription.
-typedef GpaStatus (*GpaGetCounterDescriptionPtrType)(GpaContextId, GpaUInt32, const char**);
+typedef GpaStatus (*GpaGetCounterDescriptionPtrType)(GpaSessionId, GpaUInt32, const char**);
 
 /// Typedef for a function pointer for GpaGetCounterDataType.
-typedef GpaStatus (*GpaGetCounterDataTypePtrType)(GpaContextId, GpaUInt32, GpaDataType*);
+typedef GpaStatus (*GpaGetCounterDataTypePtrType)(GpaSessionId, GpaUInt32, GpaDataType*);
 
 /// Typedef for a function pointer for GpaGetCounterUsageType.
-typedef GpaStatus (*GpaGetCounterUsageTypePtrType)(GpaContextId, GpaUInt32, GpaUsageType*);
+typedef GpaStatus (*GpaGetCounterUsageTypePtrType)(GpaSessionId, GpaUInt32, GpaUsageType*);
 
 /// Typedef for a function pointer for GpaGetCounterUuid.
-typedef GpaStatus (*GpaGetCounterUuidPtrType)(GpaContextId, GpaUInt32, GpaUuid*);
+typedef GpaStatus (*GpaGetCounterUuidPtrType)(GpaSessionId, GpaUInt32, GpaUuid*);
 
 /// Typedef for a function pointer for GpaGetCounterSampleType.
-typedef GpaStatus (*GpaGetCounterSampleTypePtrType)(GpaContextId, GpaUInt32, GpaCounterSampleType*);
+typedef GpaStatus (*GpaGetCounterSampleTypePtrType)(GpaSessionId, GpaUInt32, GpaCounterSampleType*);
 
 /// Typedef for a function pointer for GpaGetDataTypeAsStr.
 typedef GpaStatus (*GpaGetDataTypeAsStrPtrType)(GpaDataType, const char**);
@@ -87,6 +93,57 @@ typedef GpaStatus (*GpaDeleteSessionPtrType)(GpaSessionId);
 
 /// Typedef for a function pointer for GpaBeginSession.
 typedef GpaStatus (*GpaBeginSessionPtrType)(GpaSessionId);
+
+/// Typedef for a function pointer for GpaResetSession.
+typedef GpaStatus (*GpaResetSessionPtrType)(GpaSessionId);
+
+/// Typedef for a function pointer for GpaAbortSession.
+typedef GpaStatus (*GpaAbortSessionPtrType)(GpaSessionId);
+
+/// Typedef for a function pointer for GpaSqttGetInstructionMask
+typedef GpaStatus (*GpaSqttGetInstructionMaskPtrType)(GpaSessionId, GpaSqttInstructionFlags*);
+
+/// Typedef for a function pointer for GpaSqttSetInstructionMask
+typedef GpaStatus (*GpaSqttSetInstructionMaskPtrType)(GpaSessionId, GpaSqttInstructionFlags);
+
+/// Typedef for a function pointer for GpaSqttGetComputeUnitId
+typedef GpaStatus (*GpaSqttGetComputeUnitIdPtrType)(GpaSessionId, GpaUInt32*);
+
+/// Typedef for a function pointer for GpaSqttSetComputeUnitId
+typedef GpaStatus (*GpaSqttSetComputeUnitIdPtrType)(GpaSessionId, GpaUInt32);
+
+/// Typedef for a function pointer for GpaSqttBegin
+typedef GpaStatus (*GpaSqttBeginPtrType)(GpaSessionId, void*);
+
+/// Typedef for a function pointer for GpaSqttEnd
+typedef GpaStatus (*GpaSqttEndPtrType)(GpaSessionId, void*);
+
+/// Typedef for a function pointer for GpaSqttGetSampleResultSize
+typedef GpaStatus (*GpaSqttGetSampleResultSizePtrType)(GpaSessionId, size_t*);
+
+/// Typedef for a function pointer for GpaSqttGetSampleResult
+typedef GpaStatus (*GpaSqttGetSampleResultPtrType)(GpaSessionId, size_t, void*);
+
+/// Typedef for a function pointer for GpaSpmSetSampleInterval
+typedef GpaStatus (*GpaSpmSetSampleIntervalPtrType)(GpaSessionId, GpaUInt32);
+
+/// Typedef for a function pointer for GpaSpmSetDuration
+typedef GpaStatus (*GpaSpmSetDurationPtrType)(GpaSessionId, GpaUInt32);
+
+/// Typedef for a function pointer for GpaSpmBegin
+typedef GpaStatus (*GpaSpmBeginPtrType)(GpaSessionId, void*);
+
+/// Typedef for a function pointer for GpaSpmEnd
+typedef GpaStatus (*GpaSpmEndPtrType)(GpaSessionId, void*);
+
+/// Typedef for a function pointer for GpaSpmGetSampleResultSize
+typedef GpaStatus (*GpaSpmGetSampleResultSizePtrType)(GpaSessionId, size_t*);
+
+/// Typedef for a function pointer for GpaSpmGetSampleResult
+typedef GpaStatus (*GpaSpmGetSampleResultPtrType)(GpaSessionId, size_t, void*);
+
+/// Typedef for a function pointer for GpaSpmCalculateDerivedCounters
+typedef GpaStatus (*GpaSpmCalculateDerivedCountersPtrType)(GpaSessionId, GpaSpmData*, GpaUInt32, GpaUInt64*);
 
 /// Typedef for a function pointer for GpaEndSession.
 typedef GpaStatus (*GpaEndSessionPtrType)(GpaSessionId);
@@ -134,14 +191,10 @@ typedef GpaStatus (*GpaBeginSamplePtrType)(GpaUInt32, GpaCommandListId);
 typedef GpaStatus (*GpaEndSamplePtrType)(GpaCommandListId);
 
 /// Typedef for a function pointer for GpaContinueSampleOnCommandList.
-typedef GpaStatus (*GpaContinueSampleOnCommandListPtrType)(GpaUInt32,
-                                                           GpaCommandListId);
+typedef GpaStatus (*GpaContinueSampleOnCommandListPtrType)(GpaUInt32, GpaCommandListId);
 
 /// Typedef for a function pointer for GpaCopySecondarySamples.
-typedef GpaStatus (*GpaCopySecondarySamplesPtrType)(GpaCommandListId,
-                                                    GpaCommandListId,
-                                                    GpaUInt32,
-                                                    GpaUInt32*);
+typedef GpaStatus (*GpaCopySecondarySamplesPtrType)(GpaCommandListId, GpaCommandListId, GpaUInt32, GpaUInt32*);
 
 /// Typedef for a function pointer for GpaGetSampleCount.
 typedef GpaStatus (*GpaGetSampleCountPtrType)(GpaSessionId, GpaUInt32*);

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_functions.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_functions.h
@@ -1,5 +1,5 @@
 //==============================================================================
-// Copyright (c) 2014-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025 Advanced Micro Devices, Inc. All rights reserved.
 /// @author AMD Developer Tools Team
 /// @file
 /// @brief  GPA required public function declarations wrapped in a macro.
@@ -29,6 +29,8 @@ GPA_FUNCTION_PREFIX(GpaGetSupportedSampleTypes)
 GPA_FUNCTION_PREFIX(GpaGetDeviceAndRevisionId)
 GPA_FUNCTION_PREFIX(GpaGetDeviceName)
 
+GPA_FUNCTION_PREFIX(GpaUpdateDeviceInformation)
+
 // Counter Interrogation.
 GPA_FUNCTION_PREFIX(GpaGetNumCounters)
 GPA_FUNCTION_PREFIX(GpaGetCounterName)
@@ -47,6 +49,30 @@ GPA_FUNCTION_PREFIX(GpaCreateSession)
 GPA_FUNCTION_PREFIX(GpaDeleteSession)
 GPA_FUNCTION_PREFIX(GpaBeginSession)
 GPA_FUNCTION_PREFIX(GpaEndSession)
+GPA_FUNCTION_PREFIX(GpaResetSession)
+
+GPA_FUNCTION_PREFIX(GpaAbortSession)
+
+// Session Interrogation / Configuration
+GPA_FUNCTION_PREFIX(GpaSqttGetInstructionMask)
+GPA_FUNCTION_PREFIX(GpaSqttSetInstructionMask)
+GPA_FUNCTION_PREFIX(GpaSqttGetComputeUnitId)
+GPA_FUNCTION_PREFIX(GpaSqttSetComputeUnitId)
+
+// SQTT functions
+GPA_FUNCTION_PREFIX(GpaSqttBegin)
+GPA_FUNCTION_PREFIX(GpaSqttEnd)
+GPA_FUNCTION_PREFIX(GpaSqttGetSampleResultSize)
+GPA_FUNCTION_PREFIX(GpaSqttGetSampleResult)
+
+// SPM functions
+GPA_FUNCTION_PREFIX(GpaSpmSetSampleInterval)
+GPA_FUNCTION_PREFIX(GpaSpmSetDuration)
+GPA_FUNCTION_PREFIX(GpaSpmBegin)
+GPA_FUNCTION_PREFIX(GpaSpmEnd)
+GPA_FUNCTION_PREFIX(GpaSpmGetSampleResultSize)
+GPA_FUNCTION_PREFIX(GpaSpmGetSampleResult)
+GPA_FUNCTION_PREFIX(GpaSpmCalculateDerivedCounters)
 
 // Counter Scheduling.
 GPA_FUNCTION_PREFIX(GpaEnableCounter)
@@ -85,6 +111,9 @@ GPA_FUNCTION_PREFIX(GpaGetSampleId)
 
 // GPA API Version.
 GPA_FUNCTION_PREFIX(GpaGetVersion)
+
+// Context interrogation; added in 3.10
+GPA_FUNCTION_PREFIX(GpaGetDeviceGeneration)
 
 #ifdef NEED_TO_UNDEFINE_GPA_FUNCTION_PREFIX
 #undef GPA_FUNCTION_PREFIX

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_stub.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_stub.h
@@ -1,5 +1,5 @@
 //==============================================================================
-// Copyright (c) 2018-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
 /// @author AMD Developer Tools Team
 /// @file
 /// @brief  GPA Stub entry points.
@@ -57,47 +57,61 @@ static inline GpaStatus GpaGetDeviceName(GpaContextId gpa_context_id, const char
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetNumCounters(GpaContextId gpa_context_id, GpaUInt32* number_of_counters)
+static inline GpaStatus GpaUpdateDeviceInformation(GpaContextId context_id,
+                                                   GpaUInt32    num_shader_engines,
+                                                   GpaUInt32    num_compute_units,
+                                                   GpaUInt32    num_simds,
+                                                   GpaUInt32    num_waves_per_simd)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterName(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_name)
+static inline GpaStatus GpaGetDeviceGeneration(GpaContextId gpa_context_id, GpaHwGeneration* hardware_generation)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterIndex(GpaContextId gpa_context_id, const char* counter_name, GpaUInt32* counter_index)
+static inline GpaStatus GpaGetNumCounters(GpaSessionId gpa_session_id, GpaUInt32* number_of_counters)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterGroup(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_group)
+static inline GpaStatus GpaGetCounterName(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_name)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterDescription(GpaContextId gpa_context_id, GpaUInt32 index, const char** counter_description)
+static inline GpaStatus GpaGetCounterIndex(GpaSessionId gpa_session_id, const char* counter_name, GpaUInt32* counter_index)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterDataType(GpaContextId gpa_context_id, GpaUInt32 index, GpaDataType* counter_data_type)
+static inline GpaStatus GpaGetCounterGroup(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_group)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterUsageType(GpaContextId gpa_context_id, GpaUInt32 index, GpaUsageType* counter_usage_type)
+static inline GpaStatus GpaGetCounterDescription(GpaSessionId gpa_session_id, GpaUInt32 index, const char** counter_description)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterUuid(GpaContextId gpa_context_id, GpaUInt32 index, GpaUuid* counter_uuid)
+static inline GpaStatus GpaGetCounterDataType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaDataType* counter_data_type)
 {
     RETURN_GPA_SUCCESS;
 }
 
-static inline GpaStatus GpaGetCounterSampleType(GpaContextId gpa_context_id, GpaUInt32 index, GpaCounterSampleType* counter_sample_type)
+static inline GpaStatus GpaGetCounterUsageType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaUsageType* counter_usage_type)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaGetCounterUuid(GpaSessionId gpa_session_id, GpaUInt32 index, GpaUuid* counter_uuid)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaGetCounterSampleType(GpaSessionId gpa_session_id, GpaUInt32 index, GpaCounterSampleType* counter_sample_type)
 {
     RETURN_GPA_SUCCESS;
 }
@@ -123,6 +137,94 @@ static inline GpaStatus GpaDeleteSession(GpaSessionId gpa_session_id)
 }
 
 static inline GpaStatus GpaBeginSession(GpaSessionId gpa_session_id)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaResetSession(GpaSessionId gpa_session_id)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaAbortSession(GpaSessionId gpa_session_id)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttGetInstructionMask(GpaSessionId gpa_session_id, GpaSqttInstructionFlags* sqtt_instruction_mask)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttSetInstructionMask(GpaSessionId gpa_session_id, GpaSqttInstructionFlags sqtt_instruction_mask)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttGetComputeUnitId(GpaSessionId gpa_session_id, GpaUInt32* sqtt_compute_unit_id)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttSetComputeUnitId(GpaSessionId gpa_session_id, GpaUInt32 sqtt_compute_unit_id)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttBegin(GpaSessionId gpa_session_id, void* command_list)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttEnd(GpaSessionId gpa_session_id, void* command_list)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttGetSampleResultSize(GpaSessionId gpa_session_id, size_t* sample_result_size_in_bytes)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSqttGetSampleResult(GpaSessionId gpa_session_id, size_t sample_result_size_in_bytes, void* sqtt_results)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmSetSampleInterval(GpaSessionId gpa_session_id, GpaUInt32 interval)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmSetDuration(GpaSessionId gpa_session_id, GpaUInt32 ns_duration)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmBegin(GpaSessionId gpa_session_id, void* command_list)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmEnd(GpaSessionId gpa_session_id, void* command_list)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmGetSampleResultSize(GpaSessionId gpa_session_id, size_t* sample_result_size_in_bytes)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmGetSampleResult(GpaSessionId gpa_session_id, size_t sample_result_size_in_bytes, void* spm_results)
+{
+    RETURN_GPA_SUCCESS;
+}
+
+static inline GpaStatus GpaSpmCalculateDerivedCounters(GpaSessionId gpa_session_id,
+                                                       GpaSpmData*  spm_data,
+                                                       GpaUInt32    derived_counter_count,
+                                                       GpaUInt64*   derived_counter_results)
 {
     RETURN_GPA_SUCCESS;
 }

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_vk.h
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/Include/gpu_perf_api_vk.h
@@ -11,9 +11,9 @@
 #ifndef GPU_PERFORMANCE_API_GPU_PERF_API_VK_H_
 #define GPU_PERFORMANCE_API_GPU_PERF_API_VK_H_
 
-#ifndef AMD_GPUPERFAPI_SKIP_VULKAN_INCLUDE
+#ifndef VULKAN_H_
 #include <vulkan/vulkan.h>
-#endif // AMD_GPUPERFAPI_SKIP_VULKAN_INCLUDE
+#endif  // VULKAN_H_
 
 /// Define the AMD GPA extension name.
 #define VK_AMD_GPA_INTERFACE_EXTENSION_NAME "VK_AMD_gpa_interface"

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/LICENSE
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/renderdoc/driver/ihv/amd/official/GPUPerfAPI/version.txt
+++ b/renderdoc/driver/ihv/amd/official/GPUPerfAPI/version.txt
@@ -1,3 +1,3 @@
-Release: GPUPerfAPI 3.8
+Release: GPUPerfAPI 4.0
 
-https://github.com/GPUOpen-Tools/gpu_performance_api @ 643f328700a9240a29746a8a7fbed7cec100226a
+https://github.com/GPUOpen-Tools/gpu_performance_api @ b6d2e5105da73693049aa3f41b0fc52d00c1d697


### PR DESCRIPTION
* Update AMD counter integration headers with GPA 4.0, and its License file.
* Add changes to amd_counters[.h/.cpp] to accommodate GPA 4.0 backward incompatible changes.